### PR TITLE
docs: clarify main branch push policy in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,4 +37,4 @@
   4. Create a pull request with a clear description
   5. Request user review instead of merging directly
 - PRs should reference the issue they fix (e.g., "Fixes #2")
-- **IMPORTANT**: Never push directly to main. Only the repo owner can push to main unless explicitly granted permission. All changes must go through a PR for review.
+- **IMPORTANT**: Never push directly to main. Only the repo owner can push to main unless explicitly granted permission. All changes must go through a PR for review when working on GitHub issues. For other changes requested directly (not from GitHub issues), local review is acceptable.


### PR DESCRIPTION
Adds explicit documentation that only the repo owner can push directly to main. All changes must go through a PR for review.