### PR TITLE
flake.nix: cleanup duplicate HM module and dead allowUnfree

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -120,7 +120,6 @@
         modules =
           modules
           ++ [
-            home-manager.nixosModules.home-manager
             {
               home-manager.extraSpecialArgs.flake-inputs =
                 inputs
@@ -153,8 +152,6 @@
       };
     };
   in {
-    nixpkgs.config.allowUnfree = true;
-
     formatter.${system} = nixpkgs.legacyPackages.${system}.nixfmt-rfc-style;
 
     nixosConfigurations =


### PR DESCRIPTION
## Summary
This PR addresses issue #8 by cleaning up two problems in flake.nix:

1. **Remove duplicate home-manager module import**: The `home-manager.nixosModules.home-manager` was being imported twice - once in `common-modules` (line 69) and again in `mkConfig` (line 123). Since all host-specific modules are built from `common-modules`, the duplicate import in `mkConfig` is unnecessary.

2. **Remove dead allowUnfree setting**: The `nixpkgs.config.allowUnfree = true;` at the top level of flake.nix (line 156) has no effect. The same configuration is already properly set in `configuration.nix` (line 13), which is included in `common-modules`.

## Changes
- Removed duplicate `home-manager.nixosModules.home-manager` from `mkConfig`
- Removed the dead `nixpkgs.config.allowUnfree` from the outputs

## Fixes
Fixes #8